### PR TITLE
Fix for text appearance instead of icon

### DIFF
--- a/knoblock/publications.html
+++ b/knoblock/publications.html
@@ -3,6 +3,8 @@
 <head>
 	<meta charset="UTF-8">
 	<title>Craig Knoblock - Publications</title>
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
+	<link rel="stylesheet" href="css/publication.css">
 </head>
 <body>
 	<script src="https://bibbase.org/show?bib=https%3A%2F%2Fusc-isi-i2.github.io%2Fknoblock%2Fdoc%2Fknoblock.bib&jsonp=1"></script>


### PR DESCRIPTION
Since the css files were not included, Bib base was going for the default css file.